### PR TITLE
Fix Darwin version matching to support all macOS versions

### DIFF
--- a/lib/dantzig/highs_downloader.ex
+++ b/lib/dantzig/highs_downloader.ex
@@ -92,7 +92,7 @@ defmodule Dantzig.HiGHSDownloader do
     [os, suffix] = Enum.take(rest, -2)
 
     case {arch, os, suffix} do
-      {"aarch64", "apple", "darwin"} -> "aarch64-apple-darwin"
+      {"aarch64", "apple", "darwin" <> _} -> "aarch64-apple-darwin"
       {"aarch64", "linux", "gnu"} -> "aarch64-linux-gnu-cxx11"
       {"aarch64", "linux", "musl"} -> "aarch64-linux-musl-cxx11"
       {"aarch64", "unknown", "freebsd"} -> "aarch64-unknown-freebsd"


### PR DESCRIPTION
The matching for the darwin version failed for my M3 Macbook Pro with Sequoia 15.6.1.
Depending on the OS version the `:erlang.system_info(:system_architecture)` function adds suffixes to the "darwin" string.
In my case the complete string is "darwin24.4.0".

With this fix the download of the binary works and the tests succeed.