### PR TITLE
Add power operator to Operator macro

### DIFF
--- a/lib/dantzig/polynomial/operators.ex
+++ b/lib/dantzig/polynomial/operators.ex
@@ -4,7 +4,7 @@ defmodule Dantzig.Polynomial.Operators do
 
   defmacro __using__(_opts) do
     quote do
-      import Kernel, except: [+: 2, -: 2, *: 2, /: 2]
+      import Kernel, except: [+: 2, -: 2, *: 2, /: 2, **: 2]
       import unquote(__MODULE__)
     end
   end
@@ -13,4 +13,5 @@ defmodule Dantzig.Polynomial.Operators do
   def p - q, do: Polynomial.subtract(p, q)
   def p * q, do: Polynomial.multiply(p, q)
   def p / q, do: Polynomial.divide(p, q)
+  def p ** n, do: Polynomial.power(p, n)
 end


### PR DESCRIPTION
This PR adds the power operator overloading for the `**` Kernel function when working with polynomials.