### PR TITLE
Use directory to store all temporary files while solving

### DIFF
--- a/lib/dantzig/highs.ex
+++ b/lib/dantzig/highs.ex
@@ -58,23 +58,22 @@ defmodule Dantzig.HiGHS do
 
   defp with_temporary_files(basenames, fun) do
     dir = System.tmp_dir!()
-    prefix = :rand.uniform(@max_random_prefix) |> Integer.to_string(32)
+    suffix = :rand.uniform(@max_random_prefix) |> Integer.to_string(32)
+    dirname = "dantzig_highs_#{suffix}"
+
+    dirpath = Path.join(dir, dirname)
+
+    File.mkdir!(dirpath)
 
     paths =
       for basename <- basenames do
-        Path.join(dir, "#{prefix}_#{basename}")
+        Path.join(dirpath, basename)
       end
 
     try do
       fun.(paths)
     after
-      for path <- paths do
-        try do
-          File.rm!(path)
-        rescue
-          _ -> :ok
-        end
-      end
+      File.rm_rf(dirpath)
     end
   end
 


### PR DESCRIPTION
This provides cleaner way to remove them all at once as well as nice way to debug the issues with generated files.